### PR TITLE
[bug]:fix go.mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,17 +1,17 @@
 module github.com/orangekame3/mk
 
-go 1.21.0
+go 1.21
 
 require (
 	github.com/charmbracelet/bubbles v0.18.0
 	github.com/charmbracelet/bubbletea v0.26.6
-	github.com/charmbracelet/lipgloss v0.9.1
 	github.com/spf13/cobra v1.7.0
 )
 
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
+	github.com/charmbracelet/lipgloss v0.9.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.2 // indirect
 	github.com/charmbracelet/x/input v0.1.0 // indirect
 	github.com/charmbracelet/x/term v0.1.1 // indirect


### PR DESCRIPTION
## 📃 Ticket

https://github.com/orangekame3/mk/issues/9

## ✍ Description



## ✅ Checked



```Dockerfile
FROM golang:1.20

WORKDIR /app

RUN go install github.com/orangekame3/mk@fix-gomod

CMD ["mk"]
```


```bash
❯❯❯ docker build -t mk-test .
[+] Building 15.3s (7/7) FINISHED                                               docker:desktop-linux
 => [internal] load build definition from Dockerfile                                            0.0s
 => => transferring dockerfile: 131B                                                            0.0s
 => [internal] load metadata for docker.io/library/golang:1.20                                  1.6s
 => [internal] load .dockerignore                                                               0.0s
 => => transferring context: 2B                                                                 0.0s
 => [1/3] FROM docker.io/library/golang:1.20@sha256:8f9af7094d0cb27cc783c697ac5ba25efdc4da35f8  0.0s
 => CACHED [2/3] WORKDIR /app                                                                   0.0s
 => [3/3] RUN go install github.com/orangekame3/mk@fix-gomod                                   13.4s
 => exporting to image                                                                          0.2s 
 => => exporting layers                                                                         0.2s 
 => => writing image sha256:dc82ca46198d7547b6881c3baf2d00b6b910fcdfd8e4798a4abd73981e56f836    0.0s 
 => => naming to docker.io/library/mk-test  
```
```

