### PR TITLE
Release for v0.0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.0.14](https://github.com/orangekame3/mk/compare/v0.0.13...v0.0.14) - 2024-07-01
+- [Fix]: update README about Taskfile by @orangekame3 in https://github.com/orangekame3/mk/pull/23
+
 ## [v0.0.13](https://github.com/orangekame3/mk/compare/v0.0.12...v0.0.13) - 2024-06-30
 
 - chore: Update root command to support Taskfile and Makefile by @orangekame3 in <https://github.com/orangekame3/mk/pull/20>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## [v0.0.14](https://github.com/orangekame3/mk/compare/v0.0.13...v0.0.14) - 2024-07-01
-- [Fix]: update README about Taskfile by @orangekame3 in https://github.com/orangekame3/mk/pull/23
+
+- [Fix]: update README about Taskfile by @orangekame3 in <https://github.com/orangekame3/mk/pull/23>
 
 ## [v0.0.13](https://github.com/orangekame3/mk/compare/v0.0.12...v0.0.13) - 2024-06-30
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -25,7 +25,7 @@ package cmd
 import "fmt"
 
 // Version is a version of this application.
-const Version = "0.0.13"
+const Version = "0.0.14"
 
 // SetVersionInfo sets version and date to rootCmd
 func SetVersionInfo(version, date string) {


### PR DESCRIPTION
This pull request is for the next release as v0.0.14 created by [tagpr](https://github.com/Songmu/tagpr). Merging it will tag v0.0.14 to the merge commit and create a GitHub release.

You can modify this branch "tagpr-from-v0.0.13" directly before merging if you want to change the next version number or other files for the release.

<details>
<summary>How to change the next version as you like</summary>

There are two ways to do it.

- Version file
    - Edit and commit the version file specified in the .tagpr configuration file to describe the next version
    - If you want to use another version file, edit the configuration file.
- Labels convention
    - Add labels to this pull request like "tagpr:minor" or "tagpr:major"
    - If no conventional labels are added, the patch version is incremented as is.
</details>

---
<!-- Release notes generated using configuration in .github/release.yml at main -->

## What's Changed
* [Fix]: update README about Taskfile by @orangekame3 in https://github.com/orangekame3/mk/pull/23


**Full Changelog**: https://github.com/orangekame3/mk/compare/v0.0.13...v0.0.14